### PR TITLE
adding extend function and options for settings

### DIFF
--- a/fittext.js
+++ b/fittext.js
@@ -19,13 +19,20 @@
 		else
 			el.attachEvent('on'+type, fn);
   };
+  
+  var extend = function(obj,ext){
+    for(key in ext)
+      if(ext.hasOwnProperty(key))
+        obj[key] = ext[key];
+    return obj;
+  };
 
-  window.fitText = function (el, kompressor) {
+  window.fitText = function (el, kompressor, options) {
 
-    var settings = {
+    var settings = extend({
       'minFontSize' : -1/0,
       'maxFontSize' : 1/0
-    };
+    },options);
 
     var fit = function (el) {
       var compressor = kompressor || 1;


### PR DESCRIPTION
Added the ability to pass in options for minFontSize and maxFontSize when calling the fittext function. Added the extend function to update the settings object with the values passed in through the options parameter, if any.

This will now let me pass in values for minFontSize and maxFontSize when calling fittext():

fitText(document.getElementById('headline'), 1.2, {minFontSize:'50px', maxFontSize: '100px'});
